### PR TITLE
[⬆️] Migrate to prism-code-editor 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ptkdev/logger": "^1.8.0",
         "eruda": "^3.0.1",
         "filer": "^1.4.1",
-        "prism-code-editor": "^1.2.2",
+        "prism-code-editor": "^2.0.1",
         "prismjs": "^1.29.0",
         "uuid": "^9.0.1"
       },
@@ -739,9 +739,9 @@
       }
     },
     "node_modules/@types/prismjs": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.1.tgz",
-      "integrity": "sha512-Q7jDsRbzcNHIQje15CS/piKhu6lMLb9jwjxSfEIi4KcFKXW23GoJMkwQiJ8VObyfx+VmUaDcJxXaWN+cTCjVog=="
+      "version": "1.26.2",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.2.tgz",
+      "integrity": "sha512-/r7Cp7iUIk7gts26mHXD66geUC+2Fo26TZYjQK6Nr4LDfi6lmdRmMqM0oPwfiMhUwoBAOFe8GstKi2pf6hZvwA=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.3",
@@ -4767,11 +4767,11 @@
       }
     },
     "node_modules/prism-code-editor": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prism-code-editor/-/prism-code-editor-1.2.2.tgz",
-      "integrity": "sha512-jmVlSNCp40BWauhzjv3GGFmXVaZkXcuVa7G/5RWV+iSPAugYfL1gQlOkXxC+E2gd/Z3/wbQIEr5RC1kyoohqlg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/prism-code-editor/-/prism-code-editor-2.0.1.tgz",
+      "integrity": "sha512-93APxLnz6ow6TU8Mw2MC16d/Xb4k2FdjfrzIqb1finFPB/X4ejQyngEF1NkHKpggrIvR33QodW638KeN/gXEfA==",
       "dependencies": {
-        "@types/prismjs": "^1.26.0"
+        "@types/prismjs": "^1.26.2"
       }
     },
     "node_modules/prismjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
+        "@types/node": "^20.8.7",
         "@types/uuid": "^9.0.5",
         "@types/web": "^0.0.117",
         "ts-standard": "^12.0.2",
@@ -729,12 +730,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.8.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.4.tgz",
-      "integrity": "sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==",
+      "version": "20.8.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
+      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.25.1"
       }
@@ -5807,9 +5806,7 @@
       "version": "5.25.3",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
       "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "eruda": "^3.0.1",
         "filer": "^1.4.1",
         "prism-code-editor": "^2.0.1",
-        "prismjs": "^1.29.0",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -4772,14 +4771,6 @@
       "integrity": "sha512-93APxLnz6ow6TU8Mw2MC16d/Xb4k2FdjfrzIqb1finFPB/X4ejQyngEF1NkHKpggrIvR33QodW638KeN/gXEfA==",
       "dependencies": {
         "@types/prismjs": "^1.26.2"
-      }
-    },
-    "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/process": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "eruda": "^3.0.1",
     "filer": "^1.4.1",
     "prism-code-editor": "^2.0.1",
-    "prismjs": "^1.29.0",
     "uuid": "^9.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@ptkdev/logger": "^1.8.0",
     "eruda": "^3.0.1",
     "filer": "^1.4.1",
-    "prism-code-editor": "^1.2.2",
+    "prism-code-editor": "^2.0.1",
     "prismjs": "^1.29.0",
     "uuid": "^9.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@types/node": "^20.8.7",
     "@types/uuid": "^9.0.5",
     "@types/web": "^0.0.117",
     "ts-standard": "^12.0.2",

--- a/src/apps/editor.ts
+++ b/src/apps/editor.ts
@@ -143,11 +143,12 @@ export default class EditorApp implements App {
         }
       })
 
-      const language = fileLanguageMap[data.path.split('.').at(-1)?.toLowerCase()!] || 'text'
+      const fileExtension = data.path.split('.').pop()?.toLowerCase() as string
+      const language = fileLanguageMap[fileExtension] ?? 'text'
 
       const value = (await window.fs.promises.readFile(data.path)).toString()
       const editor = fullEditor(
-        win.content.querySelector<HTMLElement>('.editor')!,
+        win.content.querySelector('.editor') as HTMLElement,
         {
           language,
           theme: 'github-dark',
@@ -156,7 +157,7 @@ export default class EditorApp implements App {
       )
 
       const style = document.createElement('style')
-      style.innerHTML = `
+      style.textContent = `
       .prism-code-editor {
         border-radius: 10px 10px 0 0;
         caret-color: var(--text);
@@ -178,8 +179,6 @@ export default class EditorApp implements App {
         --editor__bg-selection-match: var(--surface-1)40;
         --editor__line-number: #636e7b;
         --editor__line-number-active: #adbac7;
-        --editor__bg-scrollbar: 210, 10%, 35%;
-        --editor__bg-fold: #768390;
         --bg-guide-indent: var(--surface-0);
         overflow: visible;
       }
@@ -189,7 +188,7 @@ export default class EditorApp implements App {
       `
       editor.scrollContainer.appendChild(style);
       (win.content.querySelector('#find') as HTMLElement).onclick = () => {
-        editor.extensions.searchWidget!.open()
+        editor.extensions.searchWidget?.open()
       }
       (win.content.querySelector('#save') as HTMLElement).onclick = async () => {
         await window.fs.promises.writeFile(data.path, editor.value)

--- a/src/apps/editor.ts
+++ b/src/apps/editor.ts
@@ -14,6 +14,26 @@ interface EditorConfig {
   path: string
 }
 
+const fileLanguageMap: {
+  [key: string]: string
+} = {
+  c: 'clike',
+  cpp: 'clike',
+  java: 'clike',
+  cs: 'clike',
+  ts: 'typescript',
+  js: 'javascript',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  jsx: 'jsx',
+  tsx: 'tsx',
+  html: 'html',
+  md: 'markdown',
+  css: 'css',
+  xml: 'xml',
+  py: 'python'
+}
+
 export default class EditorApp implements App {
   meta = {
     name: 'Editor',
@@ -123,69 +143,7 @@ export default class EditorApp implements App {
         }
       })
 
-      let language
-
-      switch (data.path.split('.').at(-1)?.toLowerCase()) {
-        case 'c':
-        case 'cs':
-        case 'cpp':
-        case 'java': {
-          language = 'clike'
-          break
-        }
-
-        case 'ts': {
-          language = 'typescript'
-          break
-        }
-
-        case 'js':
-        case 'mjs':
-        case 'cjs': {
-          language = 'javascript'
-          break
-        }
-
-        case 'jsx': {
-          language = 'jsx'
-          break
-        }
-
-        case 'tsx': {
-          language = 'tsx'
-          break
-        }
-
-        case 'html': {
-          language = 'html'
-          break
-        }
-
-        case 'md': {
-          language = 'md'
-          break
-        }
-
-        case 'css': {
-          language = 'css'
-          break
-        }
-
-        case 'xml': {
-          language = 'xml'
-          break
-        }
-
-        case 'py': {
-          language = 'python'
-          break
-        }
-
-        default: {
-          language = 'text'
-          break
-        }
-      }
+      const language = fileLanguageMap[data.path.split('.').at(-1)?.toLowerCase()!] || 'text'
 
       const value = (await window.fs.promises.readFile(data.path)).toString()
       const editor = fullEditor(

--- a/src/apps/editor.ts
+++ b/src/apps/editor.ts
@@ -2,15 +2,11 @@ import icon from '../assets/icons/editor.png'
 import { App } from '../types.ts'
 
 import { fullEditor } from 'prism-code-editor/setups'
-import Prism from 'prism-code-editor/prism-core'
-import 'prismjs/components/prism-markup.js'
-import 'prismjs/components/prism-clike.js'
-import 'prismjs/components/prism-javascript.js'
-import 'prismjs/components/prism-typescript.js'
-import 'prismjs/components/prism-jsx.js'
-import 'prismjs/components/prism-tsx.js'
-import 'prism-code-editor/languages'
-import 'prism-code-editor/prism-markdown'
+// this will also import markup, clike, javascript, typescript and jsx
+import 'prism-code-editor/grammars/tsx'
+import 'prism-code-editor/grammars/css-extras'
+import 'prism-code-editor/grammars/markdown'
+import 'prism-code-editor/grammars/python'
 
 import { FlowWindow } from '../wm.ts'
 
@@ -193,8 +189,7 @@ export default class EditorApp implements App {
 
       const value = (await window.fs.promises.readFile(data.path)).toString()
       const editor = fullEditor(
-        Prism,
-        win.content.querySelector('.editor'),
+        win.content.querySelector<HTMLElement>('.editor')!,
         {
           language,
           theme: 'github-dark',
@@ -204,7 +199,7 @@ export default class EditorApp implements App {
 
       const style = document.createElement('style')
       style.innerHTML = `
-      .prism-editor {
+      .prism-code-editor {
         border-radius: 10px 10px 0 0;
         caret-color: var(--text);
         font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
@@ -237,7 +232,7 @@ export default class EditorApp implements App {
       `
       editor.scrollContainer.appendChild(style);
       (win.content.querySelector('#find') as HTMLElement).onclick = () => {
-        editor.extensions.searchWidget.open()
+        editor.extensions.searchWidget!.open()
       }
       (win.content.querySelector('#save') as HTMLElement).onclick = async () => {
         await window.fs.promises.writeFile(data.path, editor.value)

--- a/src/apps/editor.ts
+++ b/src/apps/editor.ts
@@ -54,7 +54,7 @@ export default class EditorApp implements App {
             </a>
           </div>
         </div>
-        <div class="editor" style="flex:1;"></div>
+        <div class="editor" style="flex:1;display:grid;overflow:scroll;"></div>
         <style>
         .dropdown {
           position: absolute;
@@ -202,7 +202,7 @@ export default class EditorApp implements App {
       .prism-code-editor {
         border-radius: 10px 10px 0 0;
         caret-color: var(--text);
-        font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+        font-weight: 400;
         --editor__bg: var(--base);
         --widget__border: var(--mantle);
         --widget__bg: var(--crust);
@@ -223,8 +223,7 @@ export default class EditorApp implements App {
         --editor__bg-scrollbar: 210, 10%, 35%;
         --editor__bg-fold: #768390;
         --bg-guide-indent: var(--surface-0);
-        color-scheme: dark;
-        height: 100%;
+        overflow: visible;
       }
       .prism-search * {
         font-family: 'Satoshi', sans-serif;

--- a/src/files.d.ts
+++ b/src/files.d.ts
@@ -1,5 +1,0 @@
-declare module '*.png' {
-  const image: string
-  export = image
-}
-declare module '*.json'

--- a/src/plugins/apps.ts
+++ b/src/plugins/apps.ts
@@ -12,7 +12,7 @@ export const run = (element: HTMLDivElement): void => {
   element.style.alignItems = 'center'
   element.style.gap = '5px'
   element.style.flex = '1'
-  // @ts-expect-error
+
   window.addEventListener('app_opened', (e: AppOpenedEvent): void => {
     const appIcon = document.createElement('app')
     const app = e.detail.app
@@ -20,7 +20,7 @@ export const run = (element: HTMLDivElement): void => {
     appIcon.style.background = 'var(--surface-0)'
     appIcon.style.padding = '5px 7.5px'
     appIcon.style.borderRadius = '5px'
-    appIcon.innerHTML = `<img data-id="${win.id}" src="${app.meta.id as string}"/> ${app.meta.name}`
+    appIcon.innerHTML = `<img data-id="${win.id}" src="${app.meta.icon}"/> ${app.meta.name}`
     appIcon.onclick = async () => {
       const win = await e.detail.win
       win.focus()
@@ -28,7 +28,7 @@ export const run = (element: HTMLDivElement): void => {
     }
     element.appendChild(appIcon)
   })
-  // @ts-expect-error
+
   window.addEventListener('app_closed', (e: AppClosedEvent): void => {
     const win = e.detail.win
     element.querySelector(`img[data-id="${win.id}"]`)?.parentElement?.remove()

--- a/src/prism-code-editor.d.ts
+++ b/src/prism-code-editor.d.ts
@@ -1,3 +1,0 @@
-declare module 'prism-code-editor';
-declare module 'prism-code-editor/setups';
-declare module 'prism-code-editor/prism-core';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,11 +9,14 @@
     "jsx": "react",
     "jsxFactory": "h",
     "allowJs": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "declaration": true,
     "emitDeclarationOnly": true,
     "allowImportingTsExtensions": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["vite/client", "node"]
   }
 }


### PR DESCRIPTION
prism-code-editor 2.0.1 offers some nice bug fixes and improvements and re-exports Prism's grammars.

I changed `"moduleResolution"` to `"bundler"` in the tsconfig and added types for vite and node. This fixes many type issues and allows me to remove some unnecessary declaration files.

The app icons now load. Ignore this change if something else was intended.

Made the editor scroll so the search widget is always in view.